### PR TITLE
Cease using end-of-life (EoL) Electron 28, use version 30

### DIFF
--- a/freebsd/Makefile
+++ b/freebsd/Makefile
@@ -7,7 +7,7 @@ COMMENT=	An attempt at a native discord client for FreeBSD
 LICENSE=	BSD3CLAUSE
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
-USES=		electron:28 nodejs:20,build
+USES=		electron:30 nodejs:20,build
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	SrWither


### PR DESCRIPTION
https://github.com/freebsd/freebsd-ports/commit/7dd463216611bdc9b7e15e971a71336ac589a68d
removed end-of-life devel/electron28 from the FreeBSD ports collection.

The version that is currently packaged by the FreeBSD Project is 30.