### PR TITLE
Cease using end-of-life Electron 27 and 28, use version 30

### DIFF
--- a/freebsd/files/packagejsons/package-lock.json
+++ b/freebsd/files/packagejsons/package-lock.json
@@ -15,7 +15,7 @@
         "@electron-forge/maker-zip": "^7.2.0",
         "@types/node": "^20.9.2",
         "copyfiles": "^2.4.1",
-        "electron": "28.2.0",
+        "electron": "30.4.0",
         "electron-builder": "24.4.0",
         "typescript": "^5.2.2"
       }
@@ -2421,9 +2421,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "28.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.0.tgz",
-      "integrity": "sha512-22SylXQQ9IHtwLw4D+Z4Si7OUpeDtpHfJVTjy3yv53iLg5zJKKPOCWT4ZwgYGHQZ0eldyBrYBHF/P9FPd2CcVQ==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-30.4.0.tgz",
+      "integrity": "sha512-ric3KLPQ9anXYjtTD…uw+zZuybn9+IM9y7iEpqg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/freebsd/files/packagejsons/package.json
+++ b/freebsd/files/packagejsons/package.json
@@ -5,7 +5,7 @@
   "main": "./build/main.js",
   "scripts": {
     "build": "mkdir -p build && copyfiles -u 1 \"src/titlebar/**/*\" \"build\" && tsc -p .",
-    "run": "electron27 build/main.js",
+    "run": "electron30 build/main.js",
     "postbuild": "copyfiles -u 1 \"src/assets/**/*\" \"build\"",
     "make-app": "npm run build && npm run postbuild && npm run run",
     "clean": "rm -r build/",
@@ -58,6 +58,6 @@
     "copyfiles": "^2.4.1",
     "electron-builder": "24.4.0",
     "typescript": "^5.2.2",
-    "electron": "28.2.0"
+    "electron": "30.4.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@electron-forge/maker-zip": "^7.2.0",
         "@types/node": "^20.9.2",
         "copyfiles": "^2.4.1",
-        "electron": "28.2.0",
+        "electron": "30.4.0",
         "electron-builder": "24.4.0",
         "typescript": "^5.2.2"
       }
@@ -2421,9 +2421,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "28.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.0.tgz",
-      "integrity": "sha512-22SylXQQ9IHtwLw4D+Z4Si7OUpeDtpHfJVTjy3yv53iLg5zJKKPOCWT4ZwgYGHQZ0eldyBrYBHF/P9FPd2CcVQ==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-30.4.0.tgz",
+      "integrity": "sha512-ric3KLPQ9anXYjtTD…uw+zZuybn9+IM9y7iEpqg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "copyfiles": "^2.4.1",
     "electron-builder": "24.4.0",
     "typescript": "^5.2.2",
-    "electron": "28.2.0"
+    "electron": "30.4.0"
   }
 }


### PR DESCRIPTION
Run electron30, not electron27.

devDependencies: up from 28.2.0 to 30.4.0 for electron.